### PR TITLE
Add custom alias for rojo command

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,6 +147,44 @@ export default defineConfig({
 
 ---
 
+### `rojoAlias`
+
+**Type:** `string` **Default:** `"rojo"`
+
+Custom alias for the Rojo command executable. This allows you to use alternative
+Rojo builds or forks without modifying command calls throughout your project.
+
+On WSL (Windows Subsystem for Linux), the `.exe` extension is automatically
+appended to the alias when needed.
+
+**Examples:**
+
+```typescript
+// Use a custom Rojo build
+export default defineConfig({
+	rojoAlias: "rojo-sync",
+});
+
+// Use a fork with different features
+export default defineConfig({
+	rojoAlias: "rojo-custom",
+});
+```
+
+**Use Cases:**
+
+- Using the UpliftGames Rojo fork with syncback support
+- Testing custom Rojo builds
+- Managing multiple Rojo versions (e.g., `rojo-stable`, `rojo-beta`)
+- Project-specific Rojo configurations
+
+**WSL Behavior:**
+
+- Non-WSL: `"rojo-sync"` → executes `rojo-sync`
+- WSL: `"rojo-sync"` → executes `rojo-sync.exe`
+
+---
+
 ### `commandNames`
 
 **Type:** `object` **Default:** See below
@@ -478,6 +516,9 @@ export default defineConfig({
 		command: "rbxtsc",
 		watchOnOpen: true,
 	},
+
+	// Rojo command alias
+	rojoAlias: "rojo",
 
 	// Rojo project file path
 	rojoProjectPath: "default.project.json",

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -55,7 +55,7 @@ export async function action(commandOptions: BuildOptions = {}): Promise<void> {
 	validateOptions(commandOptions);
 
 	const config = await loadProjectConfig();
-	const rojo = getRojoCommand();
+	const rojo = getRojoCommand(config);
 
 	const outputPath = commandOptions.plugin ?? commandOptions.output ?? config.buildOutputPath;
 	const isPluginOutput = commandOptions.plugin !== undefined;

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -67,7 +67,7 @@ async function startRojoServer(
 	config: ResolvedConfig,
 	port: number,
 ): Promise<RojoServerResult> {
-	const rojo = getRojoCommand();
+	const rojo = getRojoCommand(config);
 	const activeSpinner = spinner({ cancelMessage: "Cancelling Rojo Serve" });
 	activeSpinner.start(`Starting Rojo server on port ${port}...`);
 

--- a/src/commands/syncback.ts
+++ b/src/commands/syncback.ts
@@ -80,9 +80,9 @@ export async function action(commandOptions: SyncbackOptions = {}): Promise<void
 	setupSignalHandlers();
 
 	const config = await loadProjectConfig();
-	const rojo = getRojoCommand();
+	const rojo = getRojoCommand(config);
 
-	await checkRojoSyncback();
+	await checkRojoSyncback(config);
 
 	const inputPath = commandOptions.input ?? config.syncbackInputPath;
 
@@ -126,8 +126,8 @@ function buildRojoArguments(
 	return args;
 }
 
-async function checkRojoSyncback(): Promise<void> {
-	const rojo = getRojoCommand();
+async function checkRojoSyncback(config: ResolvedConfig): Promise<void> {
+	const rojo = getRojoCommand(config);
 
 	try {
 		await runOutput(rojo, ["syncback", "--help"]);

--- a/src/commands/typegen.ts
+++ b/src/commands/typegen.ts
@@ -62,7 +62,7 @@ export async function action(commandOptions: TypegenOptions = {}): Promise<void>
 	const spinner = createSpinner("Fetching Rojo sourcemap...");
 
 	const projectPath = commandOptions.project ?? config.rojoProjectPath;
-	const rojoSourceMap = await getRojoSourceMap(projectPath);
+	const rojoSourceMap = await getRojoSourceMap(projectPath, config);
 
 	spinner.message("Generating TypeScript interfaces...");
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -43,7 +43,7 @@ export async function action(): Promise<void> {
 	setupSignalHandlers();
 
 	const config = await loadProjectConfig();
-	const rojo = getRojoCommand();
+	const rojo = getRojoCommand(config);
 
 	await stopExistingRojo(config);
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -27,6 +27,7 @@ export const defaults: ResolvedConfig = {
 		command: "rbxtsc",
 		watchOnOpen: true,
 	},
+	rojoAlias: "rojo",
 	rojoProjectPath: "default.project.json",
 	suppressNoTaskRunnerWarning: false,
 	syncback: {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -28,6 +28,7 @@ export const configSchema = type({
 		"command?": "string",
 		"watchOnOpen?": "boolean",
 	},
+	"rojoAlias?": "string",
 	"rojoProjectPath?": "string",
 	"suppressNoTaskRunnerWarning?": "boolean",
 	"syncback?": {

--- a/src/utils/rojo.ts
+++ b/src/utils/rojo.ts
@@ -3,6 +3,7 @@ import { cancel, log } from "@clack/prompts";
 import ansis from "ansis";
 import { scope, type } from "arktype";
 import process from "node:process";
+import type { ResolvedConfig } from "src/config/schema";
 
 import { isWsl } from "./is-wsl";
 import { runOutput } from "./run";
@@ -40,20 +41,27 @@ export async function checkRojoInstallation(): Promise<string> {
  * WSL (Windows Subsystem for Linux) needs to call the Windows executable (.exe)
  * to properly interact with the Windows filesystem and processes.
  *
- * @returns `rojo.exe` on WSL, `rojo` on other platforms.
+ * @param config - Optional resolved config containing the rojo alias.
+ * @returns The rojo command with `.exe` suffix on WSL, without on other
+ *   platforms.
  */
-export function getRojoCommand(): string {
-	return isWsl() ? "rojo.exe" : "rojo";
+export function getRojoCommand(config?: ResolvedConfig): string {
+	const baseCommand = config?.rojoAlias ?? "rojo";
+	return isWsl() ? `${baseCommand}.exe` : baseCommand;
 }
 
 /**
  * Executes `rojo sourcemap` and returns the parsed JSON output.
  *
  * @param rojoProjectPath - Optional path to a specific Rojo project file.
+ * @param config - Optional resolved config containing the rojo alias.
  * @returns The parsed Rojo source map.
  */
-export async function getRojoSourceMap(rojoProjectPath?: string): Promise<RojoSourceMap> {
-	const rojo = getRojoCommand();
+export async function getRojoSourceMap(
+	rojoProjectPath?: string,
+	config?: ResolvedConfig,
+): Promise<RojoSourceMap> {
+	const rojo = getRojoCommand(config);
 	const args = ["sourcemap"];
 
 	if (rojoProjectPath !== undefined && rojoProjectPath.length > 0) {


### PR DESCRIPTION
Add rojoAlias configuration option that allows users to specify a custom Rojo command executable. This enables using alternative Rojo builds or forks (e.g., rojo-sync, rojo-custom) without modifying command calls throughout the project.

The feature automatically handles WSL by appending .exe to the alias when needed, maintaining the existing WSL behavior.

Changes:
- Add rojoAlias field to config schema (defaults to "rojo")
- Update getRojoCommand() to accept config and use rojoAlias
- Update all commands (build, serve, syncback, typegen, watch) to pass config to getRojoCommand()
- Add comprehensive documentation with examples and use cases